### PR TITLE
Extend the BR5 encryption limit past the common 0x20000 byte block

### DIFF
--- a/idrivetools/file_tools/bmw_file_factory.py
+++ b/idrivetools/file_tools/bmw_file_factory.py
@@ -10,7 +10,7 @@ class BMWFileFactory:
     ext_map = {
         ".BR3": (".MP4", ".BR3", True, 0x20000),
         ".BR4": (".MP3", ".BR4", True),
-        ".BR5": (".WMA", ".BR5", True, 0x20000),
+        ".BR5": (".WMA", ".BR5", True),
         ".BR25": (".AAC", ".BR25", True),
         ".BR27": (".MP4", ".BR27", True, 0x20000),
         ".BR28": (".MP3", ".BR28", True),


### PR DESCRIPTION
Extend the BR5 encryption limit past the common 0x20000 byte block that is common in other formats